### PR TITLE
add a means for the authorise function to provide values to be set on the session

### DIFF
--- a/server.go
+++ b/server.go
@@ -18,7 +18,7 @@ type Config struct {
 	ClosingTimeout   int
 	NewSessionID     func() string
 	Transports       *TransportManager
-	Authorize        func(*http.Request, *map[interface{}]interface{}) bool
+	Authorize        func(*http.Request, map[interface{}]interface{}) bool
 }
 
 type SocketIOServer struct {
@@ -26,7 +26,7 @@ type SocketIOServer struct {
 	mutex            sync.RWMutex
 	heartbeatTimeout int
 	closingTimeout   int
-	authorize        func(*http.Request, *map[interface{}]interface{}) bool
+	authorize        func(*http.Request, map[interface{}]interface{}) bool
 	newSessionId     func() string
 	transports       *TransportManager
 	sessions         map[string]*Session
@@ -149,7 +149,7 @@ func (srv *SocketIOServer) RemoveAllListeners(name string) {
 func (srv *SocketIOServer) handShake(w http.ResponseWriter, r *http.Request) {
 	var values = make(map[interface{}]interface{})
 	if srv.authorize != nil {
-		if ok := srv.authorize(r, &values); !ok {
+		if ok := srv.authorize(r, values); !ok {
 			http.Error(w, "", 401)
 			return
 		}
@@ -184,7 +184,6 @@ func (srv *SocketIOServer) handShake(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if values != nil {
-		fmt.Println("Copying values set by authorize")
 		for k, v := range values {
 			session.Values[k] = v
 		}
@@ -208,4 +207,3 @@ func (srv *SocketIOServer) getSession(sessionId string) *Session {
 	defer srv.mutex.RUnlock()
 	return srv.sessions[sessionId]
 }
-


### PR DESCRIPTION
Adding a means for the `Authorize` method to set value which will be copied to the `Values` of a session object that is created.

While this is general purpose, and can be used for any arbitrary value, it is most useful for setting authorization related information, such as authentication tokens and user IDs.

For example, the web socket can be identified as belonging to a specific user who has authenticated via a standard HTTP request, prior to connecting though the socket.
