### PR TITLE
Fix import path error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/googollee/go-socket.io"
+	"github.com/googollee/go-socketio"
 )
 
 func main() {


### PR DESCRIPTION
`go get github.com/googollee/go-socketio` creates a folder called "go-socketio" without the dot. It used to have a dot. I noticed because my code stopped compiling. :)
