### PR TITLE
Add *http.Request to Session struct allowing you to inspect the initial ajax request

### DIFF
--- a/client.go
+++ b/client.go
@@ -69,7 +69,7 @@ func Dial(origin string) (*Client, error) {
 	if endpoint != "" {
 		emitters[""] = NewEventEmitter()
 	}
-	session := NewSession(emitters, sessionId, int(timeout), false)
+	session := NewSession(emitters, sessionId, int(timeout), false, nil)
 	transport := newWebSocket(session)
 	transport.conn = ws
 	session.transport = transport

--- a/server.go
+++ b/server.go
@@ -179,7 +179,7 @@ func (srv *SocketIOServer) handShake(w http.ResponseWriter, r *http.Request) {
 
 	session := srv.getSession(sessionId)
 	if session == nil {
-		session = NewSession(srv.eventEmitters, sessionId, srv.heartbeatTimeout, true)
+		session = NewSession(srv.eventEmitters, sessionId, srv.heartbeatTimeout, true, r)
 		srv.addSession(session)
 	}
 

--- a/session.go
+++ b/session.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
+	"net/http"
 	"sync"
 	"time"
 )
@@ -30,6 +31,8 @@ type Session struct {
 	sendHeartBeat     bool
 	defaultNS         *NameSpace
 	Values            map[interface{}]interface{}
+	Request           *http.Request
+
 }
 
 func NewSessionID() string {
@@ -46,7 +49,7 @@ func NewSessionID() string {
 	return string(b)
 }
 
-func NewSession(emitters map[string]*EventEmitter, sessionId string, timeout int, sendHeartbeat bool) *Session {
+func NewSession(emitters map[string]*EventEmitter, sessionId string, timeout int, sendHeartbeat bool, r *http.Request) *Session {
 	ret := &Session{
 		emitters:          emitters,
 		SessionId:         sessionId,
@@ -55,6 +58,7 @@ func NewSession(emitters map[string]*EventEmitter, sessionId string, timeout int
 		heartbeatTimeout:  time.Duration(timeout) * time.Second * 2 / 3,
 		connectionTimeout: time.Duration(timeout) * time.Second,
 		Values:            make(map[interface{}]interface{}),
+		Request:           r,
 	}
 	ret.defaultNS = ret.Of("")
 	return ret


### PR DESCRIPTION
This exists on the master branch with https://github.com/googollee/go-socket.io/blob/master/socket.go#L19, but I couldn't find a similar way to access this information on the 0.9.x branch

This was a quick hack, so please review critically and I would love to fix it up or put this information somewhere else if that is better.

thanks!
