### PR TITLE
It seems there is a small logic error wit the timers

### DIFF
--- a/session.go
+++ b/session.go
@@ -55,7 +55,7 @@ func NewSession(emitters map[string]*EventEmitter, sessionId string, timeout int
 		nameSpaces:        make(map[string]*NameSpace),
 		sendHeartBeat:     sendHeartbeat,
 		heartbeatTimeout:  time.Duration(timeout) * time.Second,
-		connectionTimeout: time.Duration(timeout) * time.Second * 3,
+		connectionTimeout: time.Duration(timeout) * time.Second * 1.5,
 		Values:            make(map[interface{}]interface{}),
 		Request:           r,
 	}

--- a/session.go
+++ b/session.go
@@ -32,7 +32,6 @@ type Session struct {
 	defaultNS         *NameSpace
 	Values            map[interface{}]interface{}
 	Request           *http.Request
-
 }
 
 func NewSessionID() string {
@@ -55,8 +54,8 @@ func NewSession(emitters map[string]*EventEmitter, sessionId string, timeout int
 		SessionId:         sessionId,
 		nameSpaces:        make(map[string]*NameSpace),
 		sendHeartBeat:     sendHeartbeat,
-		heartbeatTimeout:  time.Duration(timeout) * time.Second * 2 / 3,
-		connectionTimeout: time.Duration(timeout) * time.Second,
+		heartbeatTimeout:  time.Duration(timeout) * time.Second,
+		connectionTimeout: time.Duration(timeout) * time.Second * 3,
 		Values:            make(map[interface{}]interface{}),
 		Request:           r,
 	}


### PR DESCRIPTION
The heartbeat timeout is given by the server, so it you then set the heartbeat timeout on the client to 2/3th of that and the connection timeout on exactly on par with the servers heartbeat timeout, bad things will happen… This should fix issue #40

I fixed this locally a few months ago, but deleted that branch as I don't use the package anymore. So did not test this fix myself as I have no infra for it around me just now. But will ask @zhengying if he can check this one.