### PR TITLE
fixing empty emit from client

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -144,12 +144,17 @@ func (h *socketHandler) onPacket(decoder *decoder, packet *packet) ([]interface{
 		return nil, nil
 	}
 	args := c.GetArgs()
+	olen := len(args)
 	if len(args) > 0 {
 		packet.Data = &args
 		if err := decoder.DecodeData(packet); err != nil {
 			return nil, err
 		}
 	}
+	for i := len(args); i < olen; i++ {
+		args = append(args, nil)
+    }
+
 	retV := c.Call(h.socket, args)
 	if len(retV) == 0 {
 		return nil, nil


### PR DESCRIPTION
c.Args can end up a different length from the handler.go's args. This means the client can cause a panic just by not sending a second argument to it's .emit(). Proposed change just populates the args with nils so that the reflect.Zero in callers.go is hit.

edit: accidentally clicked submit. adding more to this comment