### PR TITLE
fixes #48 close the open chanel before waiting for nextReader

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -314,10 +314,12 @@ func (d *decoder) DecodeData(v *packet) error {
 func (d *decoder) decodeBinary(num int) ([][]byte, error) {
 	ret := make([][]byte, num)
 	for i := 0; i < num; i++ {
+		d.currentCloser.Close()
 		t, r, err := d.reader.NextReader()
 		if err != nil {
 			return nil, err
 		}
+		d.currentCloser = r
 		if t == engineio.MessageText {
 			return nil, fmt.Errorf("need binary")
 		}


### PR DESCRIPTION
When sending Binary data, the socket.io client strips the binary
data from the frame and replaces it with a numbered _placeholder.
Once the placeholder frame is ack'ed the client sends another
frame with the binary data.  Without this fix go-socket.io never
acks the placeholder frame and so waits indefinitely for the data
frame.