### PR TITLE
fix for #67. It will now close the packet when reading an unknown emit

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -141,11 +141,14 @@ func (h *socketHandler) onPacket(decoder *decoder, packet *packet) ([]interface{
 	}
 	c, ok := h.events[message]
 	if !ok {
+		// If the message is not recognized by the server, the decoder.currentCloser
+		// needs to be closed otherwise the server will be stuck until the e
+		decoder.Close()
 		return nil, nil
 	}
 	args := c.GetArgs()
 	olen := len(args)
-	if len(args) > 0 {
+	if olen > 0 {
 		packet.Data = &args
 		if err := decoder.DecodeData(packet); err != nil {
 			return nil, err
@@ -153,7 +156,7 @@ func (h *socketHandler) onPacket(decoder *decoder, packet *packet) ([]interface{
 	}
 	for i := len(args); i < olen; i++ {
 		args = append(args, nil)
-    }
+	}
 
 	retV := c.Call(h.socket, args)
 	if len(retV) == 0 {

--- a/parser.go
+++ b/parser.go
@@ -5,10 +5,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/googollee/go-engine.io"
 	"io"
 	"io/ioutil"
 	"strconv"
+
+	"github.com/googollee/go-engine.io"
 )
 
 const Protocol = 4
@@ -156,15 +157,19 @@ func newDecoder(r frameReader) *decoder {
 	}
 }
 
+func (d *decoder) Close() {
+	d.currentCloser.Close()
+	d.current = nil
+	d.currentCloser = nil
+}
+
 func (d *decoder) Decode(v *packet) error {
 	ty, r, err := d.reader.NextReader()
 	if err != nil {
 		return err
 	}
 	if d.current != nil {
-		d.currentCloser.Close()
-		d.current = nil
-		d.currentCloser = nil
+		d.Close()
 	}
 	defer func() {
 		if d.current == nil {
@@ -290,9 +295,7 @@ func (d *decoder) DecodeData(v *packet) error {
 		return nil
 	}
 	defer func() {
-		d.currentCloser.Close()
-		d.current = nil
-		d.currentCloser = nil
+		d.Close()
 	}()
 	decoder := json.NewDecoder(d.current)
 	if err := decoder.Decode(v.Data); err != nil {


### PR DESCRIPTION
This is a fix for #67.
Fixed the problem that the server would not respond to any other emit once an unknown emit was sent to the server.

If the message was not understood by the server, it would return right away without closing the decoder. This would lead to a hang up at this location: [Problematic Line](https://github.com/googollee/go-engine.io/blob/597faf3df88a01780a5881fafbcbccd9d5c3fab0/server_conn.go#L222)

I also took the liberty of adding a new Close() function to the decoder interface, since the lines were repeated at multiple places in the code.