### PR TITLE
Fix int/float truncation bug

### DIFF
--- a/session.go
+++ b/session.go
@@ -55,7 +55,7 @@ func NewSession(emitters map[string]*EventEmitter, sessionId string, timeout int
 		nameSpaces:        make(map[string]*NameSpace),
 		sendHeartBeat:     sendHeartbeat,
 		heartbeatTimeout:  time.Duration(timeout) * time.Second,
-		connectionTimeout: time.Duration(timeout) * time.Second * 1.5,
+		connectionTimeout: time.Duration(timeout) * time.Duration(float64(time.Second)*1.5),
 		Values:            make(map[interface{}]interface{}),
 		Request:           r,
 	}


### PR DESCRIPTION
The expression `time.Second * 1.5` is not legal, because the types are not compatible. We have to do some conversion to make it work.

Without this change, it is not possible to call `NewSession()` without causing a panic.