### PR TITLE
Make args output of NameSpace.Emit() more true to socket.io JS behaviour

### DIFF
--- a/namespace.go
+++ b/namespace.go
@@ -100,7 +100,7 @@ func (ns *NameSpace) Emit(name string, args ...interface{}) error {
 	var err error
 	switch len(args) {
 	case 0: // marshal as empty object
-		pack.args, err = json.Marshal(map[interface{}]interface{}{})
+		pack.args, err = json.Marshal(map[string]string{})
 	case 1: // marshal as single object
 		pack.args, err = json.Marshal(args[0])
 	default: // marshal as array of objects

--- a/namespace.go
+++ b/namespace.go
@@ -98,10 +98,15 @@ func (ns *NameSpace) Emit(name string, args ...interface{}) error {
 	pack.name = name
 
 	var err error
-	pack.args, err = json.Marshal(args)
-	if err != nil {
-		return err
+	switch len(args) {
+	case 0: // marshal as empty object
+		pack.args, err = json.Marshal(map[interface{}]interface{}{})
+	case 1: // marshal as single object
+		pack.args, err = json.Marshal(args[0])
+	default: // marshal as array of objects
+		pack.args, err = json.Marshal(args)
 	}
+
 	err = ns.sendPacket(pack)
 	if err != nil {
 		return err


### PR DESCRIPTION
Currently, the resulting `args` in the emitted Javascript object is always an array, regardless of how many arguments are actually passed in to `NameSpace.Emit()`. This is not in line with how the Javascript socket.io handles emitting.

This PR corrects that by considering three cases:
1) if there are no arguments passed in
- then the client should receive the equivalent of one empty JS object
2) if there is exactly one argument passed in
- then the client should receive the equivalent of one JS object that matches the input arg
3) if there are multiple arguments passed in
- then the client should receive the equivalent of an array of JS objects matching the input args