### PR TITLE
Checking for nil before calling Close

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -158,9 +158,11 @@ func newDecoder(r frameReader) *decoder {
 }
 
 func (d *decoder) Close() {
-	d.currentCloser.Close()
-	d.current = nil
-	d.currentCloser = nil
+	if d.currentCloser != nil {
+		d.currentCloser.Close()
+		d.current = nil
+		d.currentCloser = nil
+	}
 }
 
 func (d *decoder) Decode(v *packet) error {

--- a/parser.go
+++ b/parser.go
@@ -158,8 +158,10 @@ func newDecoder(r frameReader) *decoder {
 }
 
 func (d *decoder) Close() {
-	if d.currentCloser != nil {
-		d.currentCloser.Close()
+	if d != nil {
+		if d.currentCloser != nil {
+			d.currentCloser.Close()
+		}
 		d.current = nil
 		d.currentCloser = nil
 	}


### PR DESCRIPTION
Had an issue where this was panicing with a nil pointer deference occassionally and bring my service down. This check will at least stop the panics.