### PR TITLE
Workaround to panic when attempting to close nil decoder

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -158,9 +158,11 @@ func newDecoder(r frameReader) *decoder {
 }
 
 func (d *decoder) Close() {
-	d.currentCloser.Close()
-	d.current = nil
-	d.currentCloser = nil
+	if d != nil && d.currentCloser != nil {
+		d.currentCloser.Close()
+		d.current = nil
+		d.currentCloser = nil
+	}
 }
 
 func (d *decoder) Decode(v *packet) error {


### PR DESCRIPTION
This PR fixes #88, however it feels like kind of a hack around a deeper problem. Any ideas why decoder.Close() is being called in the first place if decoder is nil?