### PR TITLE
Fix nil dereference exception in handler.go

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -137,18 +137,22 @@ func (h *socketHandler) onPacket(decoder *decoder, packet *packet) ([]interface{
 	case _BINARY_ACK:
 		return nil, h.onAck(packet.Id, decoder, packet)
 	default:
-		message = decoder.Message()
+		if decoder != nil {
+			message = decoder.Message()
+		}
 	}
 	c, ok := h.events[message]
 	if !ok {
 		// If the message is not recognized by the server, the decoder.currentCloser
 		// needs to be closed otherwise the server will be stuck until the e
-		decoder.Close()
+		if decoder != nil {
+			decoder.Close()
+		}
 		return nil, nil
 	}
 	args := c.GetArgs()
 	olen := len(args)
-	if olen > 0 {
+	if olen > 0 && decoder != nil {
 		packet.Data = &args
 		if err := decoder.DecodeData(packet); err != nil {
 			return nil, err


### PR DESCRIPTION
Ok we just tested using this commit on our production and thanks to those changes we have 100% uptime so far. Before socketio would panic every now and then due to nil dereference exception in handler.go; so I suggest this is reopened and merged.

Thanks to @aitjcize for this fix, I just reopened the pull request.