### PR TITLE
Fix racy read/increment of socket.id for emits with ack

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -2,6 +2,7 @@ package socketio
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/googollee/go-engine.io"
 )
@@ -39,6 +40,7 @@ type socket struct {
 	conn      engineio.Conn
 	namespace string
 	id        int
+	mu        sync.Mutex
 }
 
 func newSocket(conn engineio.Conn, base *baseHandler) *socket {
@@ -89,6 +91,7 @@ func (s *socket) sendConnect() error {
 }
 
 func (s *socket) sendId(args []interface{}) (int, error) {
+	s.mu.Lock()
 	packet := packet{
 		Type: _EVENT,
 		Id:   s.id,
@@ -99,6 +102,8 @@ func (s *socket) sendId(args []interface{}) (int, error) {
 	if s.id < 0 {
 		s.id = 0
 	}
+	s.mu.Unlock()
+
 	encoder := newEncoder(s.conn)
 	err := encoder.Encode(packet)
 	if err != nil {


### PR DESCRIPTION
Simultaneous calls to Socket.Emit with callback is racy on socket.id:

```
  WARNING: DATA RACE
  Read by goroutine 101:
    github.com/googollee/go-socket%2eio.(*socket).sendId()
        /home/nazri/go/src/github.com/googollee/go-socket.io/socket.go:94 +0xac
    github.com/googollee/go-socket%2eio.(*socketHandler).Emit()
        /home/nazri/go/src/github.com/googollee/go-socket.io/handler.go:72 +0x492
    github.com/googollee/go-socket%2eio.(*socket).Emit()
        /home/nazri/go/src/github.com/googollee/go-socket.io/socket.go:61 +0x99
    ...

  Previous write by goroutine 98:
    github.com/googollee/go-socket%2eio.(*socket).sendId()
        /home/nazri/go/src/github.com/googollee/go-socket.io/socket.go:98 +0x15c
    github.com/googollee/go-socket%2eio.(*socketHandler).Emit()
        /home/nazri/go/src/github.com/googollee/go-socket.io/handler.go:72 +0x492
    github.com/googollee/go-socket%2eio.(*socket).Emit()
        /home/nazri/go/src/github.com/googollee/go-socket.io/socket.go:61 +0x99
    ...
```