### PR TITLE
Adding custom multiplexer support for baseHandler while adding defaul…

### DIFF
--- a/caller.go
+++ b/caller.go
@@ -6,20 +6,29 @@ import (
 	"reflect"
 )
 
-type Caller struct {
+type Caller interface {
+
+	// build an array for decoding data into.
+	GetArgs() []interface{}
+
+	// Call the function passed arguments and return results.
+	Call(so Socket, args []interface{}) []reflect.Value
+}
+
+type callFunc struct {
 	Func       reflect.Value
 	Args       []reflect.Type
 	NeedSocket bool
 }
 
-func NewCaller(f interface{}) (*Caller, error) {
+func NewCaller(f interface{}) (Caller, error) {
 	fv := reflect.ValueOf(f)
 	if fv.Kind() != reflect.Func {
 		return nil, fmt.Errorf("f is not func")
 	}
 	ft := fv.Type()
 	if ft.NumIn() == 0 {
-		return &Caller{
+		return &callFunc{
 			Func: fv,
 		}, nil
 	}
@@ -32,14 +41,15 @@ func NewCaller(f interface{}) (*Caller, error) {
 		args = args[1:]
 		needSocket = true
 	}
-	return &Caller{
+	return &callFunc{
 		Func:       fv,
 		Args:       args,
 		NeedSocket: needSocket,
 	}, nil
 }
 
-func (c *Caller) GetArgs() []interface{} {
+// build an array for decoding data into.
+func (c *callFunc) GetArgs() []interface{} {
 	ret := make([]interface{}, len(c.Args))
 	for i, argT := range c.Args {
 		if argT.Kind() == reflect.Ptr {
@@ -51,7 +61,8 @@ func (c *Caller) GetArgs() []interface{} {
 	return ret
 }
 
-func (c *Caller) Call(so Socket, args []interface{}) []reflect.Value {
+// Call the function passed arguments and return results.
+func (c *callFunc) Call(so Socket, args []interface{}) []reflect.Value {
 	var a []reflect.Value
 	diff := 0
 	if c.NeedSocket {

--- a/caller.go
+++ b/caller.go
@@ -6,20 +6,20 @@ import (
 	"reflect"
 )
 
-type caller struct {
+type Caller struct {
 	Func       reflect.Value
 	Args       []reflect.Type
 	NeedSocket bool
 }
 
-func newCaller(f interface{}) (*caller, error) {
+func NewCaller(f interface{}) (*Caller, error) {
 	fv := reflect.ValueOf(f)
 	if fv.Kind() != reflect.Func {
 		return nil, fmt.Errorf("f is not func")
 	}
 	ft := fv.Type()
 	if ft.NumIn() == 0 {
-		return &caller{
+		return &Caller{
 			Func: fv,
 		}, nil
 	}
@@ -32,14 +32,14 @@ func newCaller(f interface{}) (*caller, error) {
 		args = args[1:]
 		needSocket = true
 	}
-	return &caller{
+	return &Caller{
 		Func:       fv,
 		Args:       args,
 		NeedSocket: needSocket,
 	}, nil
 }
 
-func (c *caller) GetArgs() []interface{} {
+func (c *Caller) GetArgs() []interface{} {
 	ret := make([]interface{}, len(c.Args))
 	for i, argT := range c.Args {
 		if argT.Kind() == reflect.Ptr {
@@ -51,7 +51,7 @@ func (c *caller) GetArgs() []interface{} {
 	return ret
 }
 
-func (c *caller) Call(so Socket, args []interface{}) []reflect.Value {
+func (c *Caller) Call(so Socket, args []interface{}) []reflect.Value {
 	var a []reflect.Value
 	diff := 0
 	if c.NeedSocket {

--- a/handler.go
+++ b/handler.go
@@ -6,61 +6,121 @@ import (
 	"sync"
 )
 
+// A EventHandler registers and gets callers for events.
+type EventHandler interface {
+
+	// New generates a new event handler based on itself.
+	New() EventHandler
+
+	// On registers the function f to handle an event.
+	On(event string, f interface{}) error
+
+	// GetCaller returns the registered caller for an event.
+	Caller(event string) (*Caller, bool)
+}
+
+func newEventHandler(base EventHandler) EventHandler {
+	if base != nil {
+		return base.New()
+	}
+	return &ServeMux{
+		events: make(map[string]*Caller),
+	}
+}
+
+// ServeMux is a socket.io request multiplexer
+type ServeMux struct {
+	sync.RWMutex
+	events map[string]*Caller
+}
+
+// New generates a new event handler based on itself.
+func (m *ServeMux) New() EventHandler {
+	events := make(map[string]*Caller)
+	if m != nil && m.events != nil {
+		m.RLock()
+		for k, v := range m.events {
+			events[k] = v
+		}
+		m.RUnlock()
+	}
+	return &ServeMux{
+		events: events,
+	}
+}
+
+// On registers the function f to handle an event.
+func (m *ServeMux) On(event string, f interface{}) error {
+	c, err := NewCaller(f)
+	if err != nil {
+		return err
+	}
+	m.Lock()
+	if m.events == nil {
+		m.events = make(map[string]*Caller)
+	}
+	m.events[event] = c
+	m.Unlock()
+	return nil
+}
+
+// Caller returns the registered caller for an event.
+func (m *ServeMux) Caller(event string) (*Caller, bool) {
+	if m.events == nil {
+		return nil, false
+	}
+	m.RLock()
+	c, ok := m.events[event]
+	m.RUnlock()
+	return c, ok
+}
+
 type baseHandler struct {
-	events    map[string]*caller
+	EventHandler
 	name      string
 	broadcast BroadcastAdaptor
 }
 
 func newBaseHandler(name string, broadcast BroadcastAdaptor) *baseHandler {
 	return &baseHandler{
-		events:    make(map[string]*caller),
-		name:      name,
-		broadcast: broadcast,
+		EventHandler: newEventHandler(nil),
+		name:         name,
+		broadcast:    broadcast,
 	}
 }
 
-// On registers the function f to handle an event.
-func (h *baseHandler) On(event string, f interface{}) error {
-	c, err := newCaller(f)
-	if err != nil {
-		return err
-	}
-	h.events[event] = c
-	return nil
+// SetMux sets a new multiplexer for the handler.
+func (h *baseHandler) SetMux(mux EventHandler) {
+	h.EventHandler = mux
 }
 
 type socketHandler struct {
 	*baseHandler
 	acksmu sync.Mutex
-	acks   map[int]*caller
+	acks   map[int]*Caller
 	socket *socket
 	rooms  map[string]struct{}
 }
 
 func newSocketHandler(s *socket, base *baseHandler) *socketHandler {
-	events := make(map[string]*caller)
-	for k, v := range base.events {
-		events[k] = v
-	}
 	return &socketHandler{
 		baseHandler: &baseHandler{
-			events:    events,
-			broadcast: base.broadcast,
+			EventHandler: newEventHandler(base.EventHandler),
+			broadcast:    base.broadcast,
 		},
-		acks:   make(map[int]*caller),
+		acks:   make(map[int]*Caller),
 		socket: s,
 		rooms:  make(map[string]struct{}),
 	}
 }
 
 func (h *socketHandler) Emit(event string, args ...interface{}) error {
-	var c *caller
+	var c *Caller
 	if l := len(args); l > 0 {
 		fv := reflect.ValueOf(args[l-1])
 		if fv.Kind() == reflect.Func {
 			var err error
-			c, err = newCaller(args[l-1])
+			c, err = NewCaller(args[l-1])
 			if err != nil {
 				return err
 			}
@@ -146,7 +206,7 @@ func (h *socketHandler) onPacket(decoder *decoder, packet *packet) ([]interface{
 			message = decoder.Message()
 		}
 	}
-	c, ok := h.events[message]
+	c, ok := h.Caller(message)
 	if !ok {
 		// If the message is not recognized by the server, the decoder.currentCloser
 		// needs to be closed otherwise the server will be stuck until the e

--- a/handler_test.go
+++ b/handler_test.go
@@ -80,7 +80,7 @@ func TestHandler(t *testing.T) {
 		var handlerCalled bool
 		baseHandlerInstance := newBaseHandler("some:event", &FakeBroadcastAdaptor{})
 		socketInstance := newSocket(&FakeSockConnection{}, baseHandlerInstance)
-		c, _ := newCaller(func () {handlerCalled = true})
+		c, _ := NewCaller(func() { handlerCalled = true })
 
 		socketInstance.acks[0] = c
 		socketInstance.onPacket(newDecoder(saver), &packet{Type:_ACK, Id:0, Data:"[]", NSP:"/"})
@@ -94,7 +94,7 @@ func TestHandler(t *testing.T) {
 		var handlerCalled bool
 		baseHandlerInstance := newBaseHandler("some:event", &FakeBroadcastAdaptor{})
 		socketInstance := newSocket(&FakeSockConnection{}, baseHandlerInstance)
-		c, _ := newCaller(func () {handlerCalled = true})
+		c, _ := NewCaller(func() { handlerCalled = true })
 
 		socketInstance.acks[0] = c
 		socketInstance.onPacket(newDecoder(saver), &packet{Type:_BINARY_ACK, Id:0, Data:"[]", NSP:"/"})

--- a/namespace.go
+++ b/namespace.go
@@ -11,6 +11,9 @@ type Namespace interface {
 
 	// On registers the function f to handle an event.
 	On(event string, f interface{}) error
+
+	// SetMux sets a new multiplexer for the handler.
+	SetMux(mux EventHandler)
 }
 
 type namespace struct {

--- a/server.go
+++ b/server.go
@@ -92,6 +92,11 @@ func (s *Server) BroadcastTo(room, message string, args ...interface{}) {
 	s.namespace.BroadcastTo(room, message, args...)
 }
 
+// SetMux sets a new multiplexer for the handler.
+func (s *Server) SetMux(mux EventHandler) {
+	s.namespace.SetMux(mux)
+}
+
 func (s *Server) loop() {
 	for {
 		conn, err := s.eio.Accept()

--- a/socket.go
+++ b/socket.go
@@ -22,6 +22,9 @@ type Socket interface {
 	// On registers the function f to handle an event.
 	On(event string, f interface{}) error
 
+	// SetMux sets a new multiplexer for the handler.
+	SetMux(mux EventHandler)
+
 	// Emit emits an event with given args.
 	Emit(event string, args ...interface{}) error
 


### PR DESCRIPTION
Adding custom multiplexer support for baseHandler while adding default ServeMux to mirror current setup with ".On" function

This is to allow an external package the easy ability to define a more complex custom multiplexor that can say for example do regexp match on the event when getting the caller function, instead of using the standard map[string]*caller

I know, why would someone want to do that, for the reason of having an event that may have extra custom data in it.

Maybe there is a better way of doing this, as in overriding the core on event system, but I could't see one.