### PR TITLE
Add disconnect function

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -30,6 +30,9 @@ type Socket interface {
 	// Leave leaves the room.
 	Leave(room string) error
 
+	// Disconnect disconnect the socket.
+	Disconnect()
+
 	// BroadcastTo broadcasts an event to the room with given args.
 	BroadcastTo(room, event string, args ...interface{}) error
 }
@@ -65,6 +68,10 @@ func (s *socket) Emit(event string, args ...interface{}) error {
 		s.conn.Close()
 	}
 	return nil
+}
+
+func (s *socket) Disconnect() {
+	s.conn.Close()
 }
 
 func (s *socket) send(args []interface{}) error {


### PR DESCRIPTION
I added this function because sometimes i need to disconnect/kill/close a socket and i don't want to emit a "disconnect" event, and i think that isn't coherent use an emit vs to use a function (something to DO something).

