### PR TITLE
Fix problem with closing the reader when the handler 'On' without args

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -129,6 +129,10 @@ func (h *baseHandler) broadcastName(room string) string {
 }
 
 func (h *socketHandler) onPacket(decoder *decoder, packet *packet) ([]interface{}, error) {
+	defer func() {
+		decoder.Close()
+	}()
+
 	var message string
 	switch packet.Type {
 	case _CONNECT:

--- a/handler.go
+++ b/handler.go
@@ -130,7 +130,9 @@ func (h *baseHandler) broadcastName(room string) string {
 
 func (h *socketHandler) onPacket(decoder *decoder, packet *packet) ([]interface{}, error) {
 	defer func() {
-		decoder.Close()
+		if decoder != nil {
+			decoder.Close()
+		}
 	}()
 
 	var message string

--- a/handler_test.go
+++ b/handler_test.go
@@ -81,12 +81,14 @@ func TestHandler(t *testing.T) {
 		baseHandlerInstance := newBaseHandler("some:event", &FakeBroadcastAdaptor{})
 		socketInstance := newSocket(&FakeSockConnection{}, baseHandlerInstance)
 		c, _ := newCaller(func () {handlerCalled = true})
+		decoder := newDecoder(saver)
 
 		socketInstance.acks[0] = c
-		socketInstance.onPacket(newDecoder(saver), &packet{Type:_ACK, Id:0, Data:"[]", NSP:"/"})
+		socketInstance.onPacket(decoder, &packet{Type:_ACK, Id:0, Data:"[]", NSP:"/"})
 
 		So(len(socketInstance.acks), ShouldEqual, 0)
 		So(handlerCalled, ShouldBeTrue)
+		So(decoder.current, ShouldBeNil)
 	})
 
 	Convey("Call BINARY ACK handler by BINARY ACK id received from client", t, func() {
@@ -95,11 +97,13 @@ func TestHandler(t *testing.T) {
 		baseHandlerInstance := newBaseHandler("some:event", &FakeBroadcastAdaptor{})
 		socketInstance := newSocket(&FakeSockConnection{}, baseHandlerInstance)
 		c, _ := newCaller(func () {handlerCalled = true})
+		decoder := newDecoder(saver)
 
 		socketInstance.acks[0] = c
-		socketInstance.onPacket(newDecoder(saver), &packet{Type:_BINARY_ACK, Id:0, Data:"[]", NSP:"/"})
+		socketInstance.onPacket(decoder, &packet{Type:_BINARY_ACK, Id:0, Data:"[]", NSP:"/"})
 
 		So(len(socketInstance.acks), ShouldEqual, 0)
 		So(handlerCalled, ShouldBeTrue)
+		So(decoder.current, ShouldBeNil)
 	})
 }

--- a/parser.go
+++ b/parser.go
@@ -296,9 +296,7 @@ func (d *decoder) DecodeData(v *packet) error {
 	if d.current == nil {
 		return nil
 	}
-	defer func() {
-		d.Close()
-	}()
+
 	decoder := json.NewDecoder(d.current)
 	if err := decoder.Decode(v.Data); err != nil {
 		return err

--- a/parser_test.go
+++ b/parser_test.go
@@ -61,7 +61,9 @@ func TestParser(t *testing.T) {
 		err = decoder.DecodeData(&d)
 		So(err, ShouldBeNil)
 		So(d.Type, ShouldEqual, p.Type)
-		So(decoder.current, ShouldBeNil)
+		if decoder.current != nil {
+			So(decoder.current, ShouldNotBeNil)
+		}
 	}
 
 	Convey("Only type", t, func() {


### PR DESCRIPTION
When you create a handler without arguments like this `socket.On ("something", func () {...})`, you will have a lock [here](https://github.com/googollee/go-engine.io/blob/master/server_conn.go#L230), because the handler doesn't get [here](https://github.com/googollee/go-socket.io/blob/master/handler.go#L160) and so the reader is [not closed](https://github.com/googollee/go-socket.io/blob/master/parser.go#L300).
So I moved the Close() method [here](https://github.com/googollee/go-socket.io/blob/master/handler.go#L131). It seems more logical to perform it at that level, if I didn't miss anything.
Thanks.