### PR TITLE
Updates import path of websocket library and fixes constant truncation error.

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,7 +1,7 @@
 package socketio
 
 import (
-	"code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 	"errors"
 	"fmt"
 	"io/ioutil"

--- a/server.go
+++ b/server.go
@@ -1,7 +1,7 @@
 package socketio
 
 import (
-	"code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 	"fmt"
 	"net/http"
 	"regexp"

--- a/session.go
+++ b/session.go
@@ -55,7 +55,7 @@ func NewSession(emitters map[string]*EventEmitter, sessionId string, timeout int
 		nameSpaces:        make(map[string]*NameSpace),
 		sendHeartBeat:     sendHeartbeat,
 		heartbeatTimeout:  time.Duration(timeout) * time.Second,
-		connectionTimeout: time.Duration(timeout) * time.Second * 1.5,
+		connectionTimeout: time.Duration(timeout) * time.Millisecond * 1500,
 		Values:            make(map[interface{}]interface{}),
 		Request:           r,
 	}

--- a/websocket.go
+++ b/websocket.go
@@ -2,7 +2,7 @@ package socketio
 
 import (
 	"bytes"
-	"code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 	"io"
 	"time"
 )


### PR DESCRIPTION
The websocket library is no longer hosted on code.google.com, so I updated the path. Also, Go 1.10 flagged a truncation error in a line that computes the connection timeout, so that's fixed too.