### PR TITLE
Server->client event can not be acked

### DIFF
--- a/namespace.go
+++ b/namespace.go
@@ -5,9 +5,6 @@ import (
 	"reflect"
 
 	"github.com/googollee/go-socket.io/parser"
-	"golang.org/x/oauth2/github"
-	"golang.org/x/tools/playground/socket"
-	"github.com/coreos/etcd/clientv3/namespace"
 )
 
 type namespaceHandler struct {

--- a/namespace.go
+++ b/namespace.go
@@ -5,6 +5,9 @@ import (
 	"reflect"
 
 	"github.com/googollee/go-socket.io/parser"
+	"golang.org/x/oauth2/github"
+	"golang.org/x/tools/playground/socket"
+	"github.com/coreos/etcd/clientv3/namespace"
 )
 
 type namespaceHandler struct {
@@ -128,6 +131,7 @@ func (c *namespaceConn) Emit(event string, v ...interface{}) {
 		if lastV.Kind() == reflect.Func {
 			f := newAckFunc(last)
 			header.ID = c.conn.nextID()
+			header.NeedAck = true
 			c.acks[header.ID] = f
 			v = v[:l-1]
 		}


### PR DESCRIPTION
Server->client event can not be acked because packages contain no package id, because there are no "need ack" flag to write package id writer.