### PR TITLE
Add lock for reading.

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -73,5 +73,7 @@ func (b *broadcast) Send(ignore Socket, room, event string, args ...interface{})
 }
 
 func (b *broadcast) Len(room string) int {
+	b.RLock()
+	defer b.RUnlock()
 	return len(b.m[room])
 }


### PR DESCRIPTION
Add a reading lock for Len() function in order to prevent reading room map during write operations