### PR TITLE
Do not crash on a handler's onError method being undefined

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -147,7 +147,9 @@ func (c *conn) serveError() {
 			return
 		case msg := <-c.errorChan:
 			if handler := c.namespace(msg.namespace); handler != nil {
-				handler.onError(msg.error)
+				if handler.onError != nil {
+					handler.onError(msg.error)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Closes #255

If no `server.OnError` error event is attached this NPE (nil pointer exception) could happen.