### PR TITLE
conn: On Close, leave all rooms, and call the disconnect handler

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -87,7 +87,9 @@ func (c *conn) Close() error {
 		// For each namespace, leave all rooms, and call the disconnect handler.
 		for ns, nc := range c.namespaces {
 			nc.LeaveAll()
-			c.handlers[ns].onDisconnect(nc, "bye")
+			if nh := c.handlers[ns]; nh != nil {
+				nh.onDisconnect(nc, "bye")
+			}
 		}
 		err = c.Conn.Close()
 		close(c.quitChan)

--- a/conn.go
+++ b/conn.go
@@ -84,6 +84,11 @@ func newConn(c engineio.Conn, handlers map[string]*namespaceHandler, broadcast B
 func (c *conn) Close() error {
 	var err error
 	c.closeOnce.Do(func() {
+		// For each namespace, leave all rooms, and call the disconnect handler.
+		for ns, nc := range c.namespaces {
+			nc.LeaveAll()
+			c.handlers[ns].onDisconnect(nc, "bye")
+		}
 		err = c.Conn.Close()
 		close(c.quitChan)
 	})


### PR DESCRIPTION
These changes are intended to address two related issues:

1. When a client connection simply drops (without sending a disconnect message/packet), the handler registered with `OnDisconnect` is not called.  Instead this case is only caught by `OnError`, with the error message `"websocket: close 1001 (going away)"`.  [As was the case with v1.0](https://github.com/googollee/go-socket.io/blob/039301c93651993bc96b7b00b1c60592a31f5a1f/socket.go#L123-L130), when the socket/connection loop(s) return, a disconnect should be triggered.  In v1.4.2, this is when any of the `conn` send/receive/error loops terminate and `Close` is called.
2. When broadcast and room functions were re-added in https://github.com/googollee/go-socket.io/pull/239, disconnected (or lost as in the first issue) connections would not leave the rooms to which they have joined.

To address both issues, this updates `(*conn).Close` to leave all rooms and dispatch the disconnect handler for each namespace.

With v1.4.2, I am still experiencing other issues with frequently dropped connections (using the official socket.io.js client in a web browser) that did not exist before the major rewrite of go-socket.io/go-socket.ie (e.g. github.com/googollee/go-socket.io v0.0.0-20181214084611-0ad7206c347a was perfectly stable for the same web browser client), but I do know the cause.