### PR TITLE
Fixes bug in gin-cors example

### DIFF
--- a/example/gin-cors/main.go
+++ b/example/gin-cors/main.go
@@ -54,7 +54,7 @@ func main(){
 		s.Close()
 		return last
 	})
-	server.OnError("/", func(e error) {
+	server.OnError("/", func(s socketio.Conn, e error) {
 		fmt.Println("meet error:", e)
 	})
 	server.OnDisconnect("/", func(s socketio.Conn, msg string) {


### PR DESCRIPTION
This patch fixes a bug in gin-cors example:
```
example/gin-cors/main.go:57:22: cannot use func literal (type func(error)) as type func(socketio.Conn, error) in argument to server.OnError
```