### PR TITLE
Fix annoying reminder to call Close() on Reader (corresponds with #297)

### DIFF
--- a/parser/decoder.go
+++ b/parser/decoder.go
@@ -101,14 +101,15 @@ func (d *Decoder) DecodeArgs(types []reflect.Type) ([]reflect.Value, error) {
 		ret[i] = reflect.New(typ)
 		values[i] = ret[i].Interface()
 	}
+
+	d.DiscardLast()
 	if err := json.NewDecoder(r).Decode(&values); err != nil {
 		if err == io.EOF {
 			err = nil
 		}
 		return nil, err
 	}
-	d.lastFrame.Close()
-	d.lastFrame = nil
+
 	for i, typ := range types {
 		if typ.Kind() != reflect.Ptr {
 			ret[i] = ret[i].Elem()


### PR DESCRIPTION
Ran into the same issue as the guy with #297 but the solution he suggested seemed a bit overkill for me.
Can't we just Close the reader currently set to lastFrame before decoding the already read data to json?

It was closed after decoding to json anyway, doing it before or after shouldn't really matter as all the relevant data is accessible through r.

I could be wrong because I missed something, but the tests don't throw any errors and it seems to be cleaner than the solution suggested in #297 .