### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ func main() {
 		s.Close()
 		return last
 	})
-	server.OnError("/", func(s socketio.Conn, e error) {
+	server.OnError("/", func(e error) {
 		fmt.Println("meet error:", e)
 	})
 	server.OnDisconnect("/", func(s socketio.Conn, reason string) {


### PR DESCRIPTION
cannot use func literal (type func(socketio.Conn, error)) as type func(error) in argument to server.OnError