### PR TITLE
Set context of the engineio.Conn to socketio.Conn

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -104,6 +104,11 @@ func (c *conn) connect() error {
 	root := newNamespaceConn(c, "/", rootHandler.broadcast)
 	c.namespaces[""] = root
 	root.Join(root.ID())
+
+	for _, ns := range c.namespaces {
+		ns.SetContext(c.Conn.Context())
+	}
+
 	header := parser.Header{
 		Type: parser.Connect,
 	}


### PR DESCRIPTION
In my project, i set the context of engineio.Conn at connInitior. Here's the link: [https://github.com/tomruk/oraj/blob/master/api/socket/auth.go#L36](https://github.com/tomruk/oraj/blob/master/api/socket/auth.go#L36)

But when i want to get that context from socketio.Conn, the value is always nil. For example:

```go
IO.OnConnect("/", func(conn socketio.Conn) error {
        fmt.Println(conn.Context())
	return nil
})
```

It always prints nil. I changed some functionality in conn.go so if i set the engine.io context, it sets the socke.tio context at the very beginning.