### PR TITLE
Fix #347: slice non-namespace character out of Namespace field

### DIFF
--- a/parser/data.go
+++ b/parser/data.go
@@ -32,6 +32,7 @@ const (
 type Header struct {
 	Type      Type
 	Namespace string
+	Query     string
 	ID        uint64
 	NeedAck   bool
 }

--- a/parser/decoder.go
+++ b/parser/decoder.go
@@ -236,6 +236,11 @@ func (d *Decoder) readHeader(header *Header) (uint64, error) {
 			}
 			return bufferCount, err
 		}
+		queryPos := strings.IndexByte(header.Namespace, '?')
+		if queryPos > -1 {
+			header.Query = header.Namespace[queryPos + 1:]
+			header.Namespace = header.Namespace[:queryPos]
+		}
 	} else {
 		d.packetReader.UnreadByte()
 	}


### PR DESCRIPTION
Check if Header.Namespace field has a '?' and if so, slice it to another field Header.Query

This also fixes #361