### PR TITLE
Send to all sockets excepting one

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -31,6 +31,8 @@ type Conn interface {
 	SetContext(v interface{})
 	Namespace() string
 	Emit(msg string, v ...interface{})
+	BroadcastRoom(room string, msg string, v ...interface{})
+	BroadcastAll(msg string, v ...interface{})
 
 	// Broadcast server side apis
 	Join(room string)
@@ -254,7 +256,10 @@ func (c *conn) serveRead() {
 				if !ok {
 					conn = newNamespaceConn(c, header.Namespace, handler.broadcast)
 					c.namespaces[header.Namespace] = conn
+					// join default single-member room:
 					conn.Join(c.ID())
+					// join default all-members room:
+					conn.Join("*")
 				}
 				handler.dispatch(conn, header, "", nil)
 

--- a/namespace.go
+++ b/namespace.go
@@ -148,6 +148,14 @@ func (c *namespaceConn) Emit(event string, v ...interface{}) {
 	c.conn.write(header, args)
 }
 
+func (c *namespaceConn) BroadcastRoom(room string, event string, v ...interface{}) {
+	c.broadcast.SendExcept(c, room, event, v...)
+}
+
+func (c *namespaceConn) BroadcastAll(event string, v ...interface{}) {
+	c.broadcast.SendAllExcept(c, event, v...)
+}
+
 func (c *namespaceConn) Join(room string) {
 	c.broadcast.Join(room, c)
 }


### PR DESCRIPTION
Add old-fashioned methods to send message to all connections except one (usually a sender).
This is a real fix of #289 (it has been closed, but is not fixed for now as I can see).

Join each connected socket to default room named `*`, so we have all connections within namespace at Broadcast level. So we can fix an issue with multiple messages to single conn (if some conn is a member of multiple rooms) #364