### PR TITLE
Change named parameter in emit

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -29,7 +29,7 @@ type Conn interface {
 	Context() interface{}
 	SetContext(v interface{})
 	Namespace() string
-	Emit(msg string, v ...interface{})
+	Emit(event string, v ...interface{})
 
 	// Broadcast server side apis
 	Join(room string)


### PR DESCRIPTION
Rename named parameter in emit as `event` as per https://github.com/googollee/go-socket.io/issues/392