### PR TITLE
Add TimestampFromClock(); add Clock interface for mocking time.Now()

### DIFF
--- a/engineio/base/util.go
+++ b/engineio/base/util.go
@@ -4,9 +4,23 @@ import "time"
 
 var chars = []byte("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_")
 
+type clock interface {
+	Now() time.Time
+}
+
+type timeClock struct{}
+
+func (timeClock) Now() time.Time {
+	return time.Now()
+}
+
 // Timestamp returns a string based on different nano time.
 func Timestamp() string {
-	now := time.Now().UnixNano()
+	return TimestampFromClock(timeClock{})
+}
+
+func TimestampFromClock(c clock) string {
+	now := c.Now().UnixNano()
 	ret := make([]byte, 0, 16)
 	for now > 0 {
 		ret = append(ret, chars[int(now%int64(len(chars)))])

--- a/engineio/base/util_test.go
+++ b/engineio/base/util_test.go
@@ -1,15 +1,23 @@
 package base
 
 import (
-	"testing"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
 )
 
-func TestTimestamp(t *testing.T) {
+type testClock struct {
+	now time.Time
+}
+
+func (c testClock) Now() time.Time {
+	return c.now
+}
+
+func TestTimestampFromClock(t *testing.T) {
 	should := assert.New(t)
-	t1 := Timestamp()
-	t2 := Timestamp()
+	t1 := TimestampFromClock(testClock{time.Unix(0, 1000)})
+	t2 := TimestampFromClock(testClock{time.Unix(0, 2000)})
 	should.NotEmpty(t1)
 	should.NotEmpty(t2)
 	should.NotEqual(t1, t2)


### PR DESCRIPTION
Fixes issue #427 