### PR TITLE
Remove fmt.Println("resume") from Payload's Resume

### DIFF
--- a/engineio/payload/payload.go
+++ b/engineio/payload/payload.go
@@ -236,7 +236,6 @@ func (p *Payload) Pause() {
 // Resume resumes the payload.
 // It can call in multi-goroutine.
 func (p *Payload) Resume() {
-	fmt.Println("resume")
 	p.pauser.Resume()
 }
 


### PR DESCRIPTION
Address #552 by just removing `fmt.Println("resume")` it