### PR TITLE
Add DB option to RedisAdapterOptions

### DIFF
--- a/_examples/README.md
+++ b/_examples/README.md
@@ -64,7 +64,8 @@ _, err := server.Adapter(&socketio.RedisAdapterOptions{
     Addr:   "127.0.0.1:6379",
     Host:   "127.0.0.1",
     Port:   "6379",
-    Prefix: "socket.io",
+    Prefix: "socket.io", 
+    DB: 1,
 })
 if err != nil {
     log.Fatal("error:", err)

--- a/adapter_options.go
+++ b/adapter_options.go
@@ -12,6 +12,8 @@ type RedisAdapterOptions struct {
 	Prefix   string
 	Network  string
 	Password string
+	// DB : specifies the database to select when dialing a connection.
+	DB int
 }
 
 func (ro *RedisAdapterOptions) getAddr() string {

--- a/redis_broadcast.go
+++ b/redis_broadcast.go
@@ -84,6 +84,9 @@ func newRedisBroadcast(nsp string, opts *RedisAdapterOptions) (*redisBroadcast, 
 	if len(opts.Password) > 0 {
 		redisOpts = append(redisOpts, redis.DialPassword(opts.Password))
 	}
+	if opts.DB > 0 {
+		redisOpts = append(redisOpts, redis.DialDatabase(opts.DB))
+	}
 
 	pub, err := redis.Dial(opts.Network, addr, redisOpts...)
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -34,6 +34,9 @@ func (s *Server) Adapter(opts *RedisAdapterOptions) (bool, error) {
 	if len(opts.Password) > 0 {
 		redisOpts = append(redisOpts, redis.DialPassword(opts.Password))
 	}
+	if opts.DB > 0 {
+		redisOpts = append(redisOpts, redis.DialDatabase(opts.DB))
+	}
 
 	conn, err := redis.Dial(opts.Network, opts.getAddr(), redisOpts...)
 	if err != nil {


### PR DESCRIPTION
Add `DB` option to `RedisAdapterOptions` for specifies the database in `redis.Dial`