### PR TITLE
[Fixed] Resoved the sessions leak(connections & mem)

### DIFF
--- a/_examples/README.md
+++ b/_examples/README.md
@@ -38,10 +38,13 @@ func main() {
 	})
 
 	server.OnError("/", func(s socketio.Conn, e error) {
+		// server.Remove(s.ID())
 		fmt.Println("meet error:", e)
 	})
 
 	server.OnDisconnect("/", func(s socketio.Conn, reason string) {
+		// Add the Remove session id. Fixed the connection & mem leak
+		server.Remove(s.ID())
 		fmt.Println("closed", reason)
 	})
 

--- a/server.go
+++ b/server.go
@@ -203,6 +203,11 @@ func (s *Server) Count() int {
 	return s.engine.Count()
 }
 
+// Remove session from sessions pool. Fixed the sessions map leak(connections, mem).
+func (s *Server) Remove(sid string) {
+	s.engine.Remove(sid)
+}
+
 // ForEach sends data by DataFunc, if room does not exit sends anything.
 func (s *Server) ForEach(namespace string, room string, f EachFunc) bool {
 	nspHandler := s.getNamespace(namespace)


### PR DESCRIPTION
Fixed the leak, everything is quiet.

First，the services connections not  growing，it's keep consistent with the number of socket connections（1w+ connections  of 1.1 G mem）， 
eg1.
<img width="1436" alt="image" src="https://github.com/googollee/go-socket.io/assets/20876892/f25c31a3-38da-482d-a9f2-7627777da740">
eg2.
![image](https://github.com/googollee/go-socket.io/assets/20876892/37f8644d-272e-4638-98d2-a751573f084c)

Second，the machine fd has down，will not cause fd to spike and cause excessive machine load 
eg1.
![image](https://github.com/googollee/go-socket.io/assets/20876892/abe89354-4344-4de6-b043-7d2cbbc58132)
