### PR TITLE
Fix(ish) for unicode encoding in packet

### DIFF
--- a/engineio/payload/data_test.go
+++ b/engineio/payload/data_test.go
@@ -20,18 +20,18 @@ var tests = []struct {
 		{frame.String, packet.OPEN, []byte{}},
 	},
 	},
-	{true, []byte{0x00, 0x01, 0x03, 0xff, '4', 'h', 'e', 'l', 'l', 'o', ' ', 0xe4, 0xbd, 0xa0, 0xe5, 0xa5, 0xbd},
+	{true, []byte{0x00, 0x09, 0xff, '4', 'h', 'e', 'l', 'l', 'o', ' ', 0xe4, 0xbd, 0xa0, 0xe5, 0xa5, 0xbd},
 		[]Packet{
 			{frame.String, packet.MESSAGE, []byte("hello 你好")},
 		},
 	},
-	{true, []byte{0x01, 0x01, 0x03, 0xff, 0x04, 'h', 'e', 'l', 'l', 'o', ' ', 0xe4, 0xbd, 0xa0, 0xe5, 0xa5, 0xbd}, []Packet{
+	{true, []byte{0x01, 0x09, 0xff, 0x04, 'h', 'e', 'l', 'l', 'o', ' ', 0xe4, 0xbd, 0xa0, 0xe5, 0xa5, 0xbd}, []Packet{
 		{frame.Binary, packet.MESSAGE, []byte("hello 你好")},
 	},
 	},
 	{true, []byte{
 		0x01, 0x07, 0xff, 0x04, 'h', 'e', 'l', 'l', 'o', '\n',
-		0x00, 0x08, 0xff, '4', 0xe4, 0xbd, 0xa0, 0xe5, 0xa5, 0xbd, '\n',
+		0x00, 0x04, 0xff, '4', 0xe4, 0xbd, 0xa0, 0xe5, 0xa5, 0xbd, '\n',
 		0x00, 0x06, 0xff, '2', 'p', 'r', 'o', 'b', 'e',
 	}, []Packet{
 		{frame.Binary, packet.MESSAGE, []byte("hello\n")},
@@ -43,7 +43,7 @@ var tests = []struct {
 		{frame.String, packet.OPEN, []byte{}},
 	},
 	},
-	{false, []byte("13:4hello 你好"), []Packet{
+	{false, []byte("9:4hello 你好"), []Packet{
 		{frame.String, packet.MESSAGE, []byte("hello 你好")},
 	},
 	},
@@ -51,10 +51,37 @@ var tests = []struct {
 		{frame.Binary, packet.MESSAGE, []byte("hello 你好")},
 	},
 	},
-	{false, []byte("10:b4aGVsbG8K8:4你好\n6:2probe"), []Packet{
+	{false, []byte("10:b4aGVsbG8K4:4你好\n6:2probe"), []Packet{
 		{frame.Binary, packet.MESSAGE, []byte("hello\n")},
 		{frame.String, packet.MESSAGE, []byte("你好\n")},
 		{frame.String, packet.PING, []byte("probe")},
+	},
+	},
+	// ↓ is 3 bytes, JavaScript `.length` 1 See https://socket.io/docs/v4/engine-io-protocol/#from-v3-to-v4
+	{false, []byte("6:412↓453:41↓"), []Packet{
+		{frame.String, packet.MESSAGE, []byte("12↓45")},
+		{frame.String, packet.MESSAGE, []byte("1↓")},
+	},
+	},
+	// 🇩🇪 is 8 bytes, 2 unicode chars JavaScript `.length` 4
+	{false, []byte("6:4hello6:4🇩🇪a5:41234"), []Packet{
+		{frame.String, packet.MESSAGE, []byte("hello")},
+		{frame.String, packet.MESSAGE, []byte("🇩🇪a")},
+		{frame.String, packet.MESSAGE, []byte("1234")},
+	},
+	},
+	// € is 3 bytes, JavaScript `.length` 1
+	{false, []byte("2:4h3:4€a2:41"), []Packet{
+		{frame.String, packet.MESSAGE, []byte("h")},
+		{frame.String, packet.MESSAGE, []byte("€a")},
+		{frame.String, packet.MESSAGE, []byte("1")},
+	},
+	},
+	//👍 is 4 bytes, JavaScript `.length` 2
+	{false, []byte("2:4h4:4👍a2:41"), []Packet{
+		{frame.String, packet.MESSAGE, []byte("h")},
+		{frame.String, packet.MESSAGE, []byte("👍a")},
+		{frame.String, packet.MESSAGE, []byte("1")},
 	},
 	},
 }

--- a/engineio/payload/decoder.go
+++ b/engineio/payload/decoder.go
@@ -37,13 +37,10 @@ func (d *decoder) NextReader() (frame.Type, packet.Type, io.ReadCloser, error) {
 		if err != nil {
 			return 0, 0, nil, err
 		}
-
 		br, ok := r.(byteReader)
-
 		if !ok {
 			br = bufio.NewReader(r)
 		}
-
 		if err := d.setNextReader(br, supportBinary); err != nil {
 			return 0, 0, nil, d.sendError(err)
 		}
@@ -129,7 +126,6 @@ func (d *decoder) sendError(err error) error {
 }
 
 func (d *decoder) textRead(r byteReader) (frame.Type, packet.Type, int64, error) {
-
 	l, err := readTextLen(r)
 	if err != nil {
 		return 0, 0, 0, err
@@ -157,7 +153,6 @@ func (d *decoder) textRead(r byteReader) (frame.Type, packet.Type, int64, error)
 
 func (d *decoder) binaryRead(r byteReader) (frame.Type, packet.Type, int64, error) {
 	b, err := r.ReadByte()
-
 	if err != nil {
 		return 0, 0, 0, err
 	}
@@ -167,7 +162,6 @@ func (d *decoder) binaryRead(r byteReader) (frame.Type, packet.Type, int64, erro
 	ft := frame.ByteToFrameType(b)
 
 	l, err := readBinaryLen(r)
-
 	if err != nil {
 		return 0, 0, 0, err
 	}

--- a/engineio/payload/decoder_test.go
+++ b/engineio/payload/decoder_test.go
@@ -96,7 +96,7 @@ func TestDecoderNextReaderError(t *testing.T) {
 
 func BenchmarkStringDecoder(b *testing.B) {
 	feeder := fakeReaderFeeder{
-		data:          []byte("8:4你好\n6:2probe"),
+		data:          []byte("4:4你好\n6:2probe"),
 		supportBinary: false,
 	}
 	d := decoder{
@@ -148,7 +148,7 @@ func BenchmarkBinaryDecoder(b *testing.B) {
 	feeder := fakeReaderFeeder{
 		data: []byte{
 			0x01, 0x07, 0xff, 0x04, 'h', 'e', 'l', 'l', 'o', '\n',
-			0x00, 0x08, 0xff, '4', 0xe4, 0xbd, 0xa0, 0xe5, 0xa5, 0xbd, '\n',
+			0x00, 0x04, 0xff, '4', 0xe4, 0xbd, 0xa0, 0xe5, 0xa5, 0xbd, '\n',
 			0x00, 0x06, 0xff, '2', 'p', 'r', 'o', 'b', 'e',
 		},
 		supportBinary: true,

--- a/engineio/payload/encoder.go
+++ b/engineio/payload/encoder.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"io"
+	"unicode/utf8"
 
 	"github.com/googollee/go-socket.io/engineio/frame"
 	"github.com/googollee/go-socket.io/engineio/packet"
@@ -56,6 +57,7 @@ func (e *encoder) Write(p []byte) (int, error) {
 	if e.b64Writer != nil {
 		return e.b64Writer.Write(p)
 	}
+	// Need to scan here and add unicode chars to the list
 	return e.frameCache.Write(p)
 }
 
@@ -92,8 +94,8 @@ func (e *encoder) Close() error {
 }
 
 func (e *encoder) writeTextHeader() error {
-	l := int64(e.frameCache.Len() + 1) // length for packet type
-	err := writeTextLen(l, &e.header)
+
+	err := writeTextLen(e.calcCodeUnitLength(), &e.header)
 	if err == nil {
 		err = e.header.WriteByte(e.pt.StringByte())
 	}
@@ -101,7 +103,7 @@ func (e *encoder) writeTextHeader() error {
 }
 
 func (e *encoder) writeB64Header() error {
-	l := int64(e.frameCache.Len() + 2) // length for 'b' and packet type
+	l := int64(utf8.RuneCount(e.frameCache.Bytes()) + 2) // length for 'b' and packet type
 	err := writeTextLen(l, &e.header)
 	if err == nil {
 		err = e.header.WriteByte('b')
@@ -112,8 +114,34 @@ func (e *encoder) writeB64Header() error {
 	return err
 }
 
+func (e *encoder) calcCodeUnitLength() int64 {
+	var l int64 = 1
+	var codeUnitSize int64 = 0
+	bytes := e.frameCache.Bytes()
+	for i := range bytes {
+		b := bytes[i]
+		if b>>3 == 30 {
+			// starts with 11110 4 byte unicode char, probably 2 length in JS
+			codeUnitSize = 2
+		} else if b>>4 == 14 {
+			// starts with 1110 3 byte unicode char, probably 2 length in JS
+			codeUnitSize = 1
+		} else if b>>5 == 6 {
+			// starts with 110 2 byte unicode char, , probably 1 length in JS
+			codeUnitSize = 1
+		} else if b>>6 == 2 {
+			// starts with 10 just unicode byte
+			codeUnitSize = 0
+		} else {
+			codeUnitSize = 1
+		}
+		l = l + codeUnitSize
+	}
+
+	return int64(l)
+}
 func (e *encoder) writeBinaryHeader() error {
-	l := int64(e.frameCache.Len() + 1) // length for packet type
+	l := int64(e.calcCodeUnitLength()) // length for packet type
 	b := e.pt.StringByte()
 	if e.ft == frame.Binary {
 		b = e.pt.BinaryByte()

--- a/engineio/payload/encoder.go
+++ b/engineio/payload/encoder.go
@@ -124,7 +124,7 @@ func (e *encoder) calcCodeUnitLength() int64 {
 			// starts with 11110 4 byte unicode char, probably 2 length in JS
 			codeUnitSize = 2
 		} else if b>>4 == 14 {
-			// starts with 1110 3 byte unicode char, probably 2 length in JS
+			// starts with 1110 3 byte unicode char, probably 1 length in JS
 			codeUnitSize = 1
 		} else if b>>5 == 6 {
 			// starts with 110 2 byte unicode char, , probably 1 length in JS

--- a/engineio/payload/encoder.go
+++ b/engineio/payload/encoder.go
@@ -116,7 +116,7 @@ func (e *encoder) writeB64Header() error {
 
 func (e *encoder) calcCodeUnitLength() int64 {
 	var l int64 = 1
-	var codeUnitSize int64 = 0
+	var codeUnitSize int64
 	bytes := e.frameCache.Bytes()
 	for i := range bytes {
 		b := bytes[i]


### PR DESCRIPTION
So this is a horrible problem and I am pretty sure this is not a 100% fix, but does fix some of the problems.

The packet encoding which includes the length of the packet data is incorrect because Javascript.length is not byte length and not Rune length, there is no direct analog in Golang but Javascript length is always less than either of those. Add to that, we must do this encoding/decoding in a stream makes it even harder.


I fixed this in
1. Decode: increasing the limit of the limit reader while reading the packet based on the unicode header we just saw, this means the packet reader will keep reading further
2. Encode: increasing the calculated length by scanning for unicode header bytes and adding to the length based on their byte value.

Both these solution are not 100% because the utf-8 header bytes are not a 1-1 value with the UCS-2 that JS uses. The proper solution would be to upgrade to socket.io version 4 (which fixes this using seperator bytes), but I need version 3 to at least kind-of work.

I have not performance tested either decoding or encoding, but I am pretty sure there wont be a massive overhead.

I added some tests, and fixed the old tests that were incorrect and errored when talking to a JS server with.

Without this fix you get some knarly errors where readers end half way though a message, or send to Javascript the incorrect amount of bytes which can cause server errors.

Reading more here:
https://mathiasbynens.be/notes/javascript-encoding
https://socket.io/blog/engine-io-4-release/#packet-encoding
https://socket.io/docs/v4/engine-io-protocol/#from-v3-to-v4
