### PR TITLE
Allowing acks to have a body

### DIFF
--- a/connection_handlers.go
+++ b/connection_handlers.go
@@ -3,23 +3,49 @@ package socketio
 import (
 	"log"
 
+	"github.com/googollee/go-socket.io/logger"
 	"github.com/googollee/go-socket.io/parser"
 )
 
-var readHandlerMapping = map[parser.Type]readHandler{
-	parser.Ack:        ackPacketHandler,
-	parser.Connect:    connectPacketHandler,
-	parser.Disconnect: disconnectPacketHandler,
-}
+var emtpyFH = newAckFunc(func() {})
 
 func ackPacketHandler(c *conn, header parser.Header) error {
-	conn, ok := c.namespaces.Get(header.Namespace)
+	nc, ok := c.namespaces.Get(header.Namespace)
 	if !ok {
 		_ = c.decoder.DiscardLast()
 		return nil
 	}
 
-	conn.dispatch(header)
+	defer nc.ack.Delete(header.ID)
+
+	rawFunc, ok := nc.ack.Load(header.ID)
+	if !ok {
+		// No function for this ack, but still need to read body
+		rawFunc = emtpyFH
+	}
+
+	handler, ok := rawFunc.(*funcHandler)
+	if !ok {
+		// This should never get here and would be solved with generic sync.Map
+		logger.Info("Incorrect Ack functinxo type")
+		rawFunc = emtpyFH // keep going
+	}
+
+	// Read the body because Ack can have body as well
+	args, err := c.decoder.DecodeArgs(handler.argTypes)
+	if err != nil {
+		logger.Info("Error decoding the ACK message type", "namespace", header.Namespace, "eventType", handler.argTypes, "err", err.Error())
+		c.onError(header.Namespace, err)
+		return errDecodeArgs
+	}
+
+	// Return value is ignored
+	_, err = handler.Call(args)
+	if err != nil {
+		logger.Info("Error for event type", "namespace", header.Namespace)
+		c.onError(header.Namespace, err)
+		return errHandleDispatch
+	}
 
 	return nil
 }
@@ -49,7 +75,7 @@ func eventPacketHandler(c *conn, event string, header parser.Header) error {
 		return errHandleDispatch
 	}
 
-	if len(ret) > 0 {
+	if len(ret) > 0 || header.NeedAck {
 		header.Type = parser.Ack
 		c.write(header, ret...)
 	}

--- a/connection_handlers_test.go
+++ b/connection_handlers_test.go
@@ -1,0 +1,80 @@
+package socketio
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/googollee/go-socket.io/engineio/session"
+	"github.com/googollee/go-socket.io/parser"
+)
+
+type testStr struct {
+	Result string `json:"result,omitempty"`
+}
+
+type fakeReader struct {
+	data  [][]byte
+	index int
+	buf   *bytes.Buffer
+}
+
+func (r *fakeReader) NextReader() (session.FrameType, io.ReadCloser, error) {
+	if r.index >= len(r.data) {
+		return 0, nil, io.EOF
+	}
+	r.buf = bytes.NewBuffer(r.data[r.index])
+	ft := session.BINARY
+	if r.index == 0 {
+		ft = session.TEXT
+	}
+	return ft, r, nil
+}
+
+func (r *fakeReader) Read(p []byte) (int, error) {
+	return r.buf.Read(p)
+}
+
+func (r *fakeReader) Close() error {
+	r.index++
+	return nil
+}
+
+func TestAck(t *testing.T) {
+	should := assert.New(t)
+	must := require.New(t)
+
+	namespace := "/test"
+	var id uint64 = 12
+	c := &conn{
+		handlers:   newNamespaceHandlers(),
+		namespaces: newNamespaces(),
+		decoder:    parser.NewDecoder(&fakeReader{data: [][]byte{[]byte("3-/test,12[{\"result\":\"pass\"}]")}}),
+	}
+
+	conn := newNamespaceConn(c, namespace, nil)
+	c.namespaces.Set(namespace, conn)
+
+	header := parser.Header{}
+
+	called := false
+	f := newAckFunc(func(t *testStr) {
+		called = true
+		should.Equal("pass", t.Result)
+	})
+	conn.ack.Store(id, f)
+
+	event := "a"
+
+	err := c.decoder.DecodeHeader(&header, &event)
+	must.NoError(err)
+	should.Equal(parser.Ack, header.Type)
+	should.Equal(12, int(header.ID))
+	should.Equal("/test", header.Namespace)
+	err = ackPacketHandler(c, header)
+	must.NoError(err)
+	must.True(called)
+}

--- a/namespace_conn.go
+++ b/namespace_conn.go
@@ -1,7 +1,6 @@
 package socketio
 
 import (
-	"fmt"
 	"reflect"
 	"sync"
 
@@ -105,31 +104,4 @@ func (nc *namespaceConn) LeaveAll() {
 
 func (nc *namespaceConn) Rooms() []string {
 	return nc.broadcast.Rooms(nc)
-}
-
-func (nc *namespaceConn) dispatch(header parser.Header) {
-	if header.Type != parser.Ack {
-		return
-	}
-
-	rawFunc, ok := nc.ack.Load(header.ID)
-	if ok {
-		f, ok := rawFunc.(*funcHandler)
-		if !ok {
-			nc.conn.onError(nc.namespace, fmt.Errorf("incorrect data stored for header %d", header.ID))
-			return
-		}
-
-		nc.ack.Delete(header.ID)
-
-		args, err := nc.conn.parseArgs(f.argTypes)
-		if err != nil {
-			nc.conn.onError(nc.namespace, err)
-			return
-		}
-		if _, err := f.Call(args); err != nil {
-			nc.conn.onError(nc.namespace, err)
-			return
-		}
-	}
 }

--- a/server.go
+++ b/server.go
@@ -308,13 +308,12 @@ func (s *Server) serveRead(c *conn) {
 
 		var err error
 		switch header.Type {
-		case parser.Ack, parser.Connect, parser.Disconnect:
-			handler, ok := readHandlerMapping[header.Type]
-			if !ok {
-				return
-			}
-
-			err = handler(c, header)
+		case parser.Ack:
+			err = ackPacketHandler(c, header)
+		case parser.Connect:
+			err = connectPacketHandler(c, header)
+		case parser.Disconnect:
+			err = disconnectPacketHandler(c, header)
 		case parser.Event:
 			err = eventPacketHandler(c, event, header)
 		}


### PR DESCRIPTION
Ack messages returned to the server can have a body attached that can contain information.

This PR allows the Ack function to recieve that information and use it.

This PR also,
1. Adds a test for the acknowledgement function being called with a body
2. cleans up some code
3. Fixes error where an Ack is not returned if required
